### PR TITLE
feat: mark italian cities in drop down menu

### DIFF
--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -50,6 +50,8 @@ const italianCities = new Set([
   "Napoli",
   "Firenze",
   "Milano",
+  "Lombardia",
+  "Veneto",
 ]);
 
 export async function loader({ context }: Route.LoaderArgs) {

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -44,11 +44,22 @@ export function meta() {
   ];
 }
 
+const italianCities = new Set([
+  "Venezia",
+  "Roma",
+  "Napoli",
+  "Firenze",
+  "Milano",
+]);
+
 export async function loader({ context }: Route.LoaderArgs) {
   const result = await apiFetch<AdminAreasResult>(context, `v1/admin-areas`);
   return result.adminAreas.map(
     (adminArea): AdminArea => ({
       ...adminArea,
+      name: italianCities.has(adminArea.name)
+        ? `${adminArea.name} (Italia)`
+        : adminArea.name,
       hash: encodeOsmId(adminArea.osmId),
     }),
   );


### PR DESCRIPTION
##  🖊️ Description
**💡 What? Why? How?**

For an event at the italian consulate, we temporarily include 5 italian cities to the score.
In the frontend we simply mark them with "(Italia)" in the drop down.



