### PR TITLE
chore: remove "Give feedback" link from start page

### DIFF
--- a/app/components/FaqLinks.tsx
+++ b/app/components/FaqLinks.tsx
@@ -43,11 +43,6 @@ export default function FaqLinks(props: ComponentProps<"div">) {
               <T _str="How can I contribute?" />
             </FaqLink>
           </li>
-          <li>
-            <FaqLink to="/faqs/give-feedback">
-              <T _str="Give feedback" />
-            </FaqLink>
-          </li>
         </ul>
       </nav>
     </div>


### PR DESCRIPTION
## What

Removes the **"Give feedback"** link (rendered as *"Feedback geben"* in German) from the shared `FaqLinks` component (`app/components/FaqLinks.tsx`).

## Why

Requested removal of the "Feedback geben" link from the start page.

## Scope

`FaqLinks` is rendered both on the start page (`app/routes/home.tsx`) and in the FAQ sidebar (`app/layouts/faq.tsx`), so the link is removed from **both** places.

Note: the `/faqs/give-feedback` page and its content (`content/{de,en}/faqs/feedback.md`, `app/utils/content.ts`) are left in place — only the link is removed. Cleaning up the now-unlinked page can be a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216012678317436